### PR TITLE
Make tracebacks show the relevant files

### DIFF
--- a/src/preprocessor.lua
+++ b/src/preprocessor.lua
@@ -76,7 +76,7 @@ local function _load(path, line, data, t)
 		data = compile(data)
 	end
 
-	local l, err = loadstring(data)
+	local l, err = loadstring(data, "@" .. path)
 
 	if not l then
 		local err_line = tonumber(err:match(":(%d+):"))


### PR DESCRIPTION
This PR replaces the "(load)" in error tracebacks with the actual file that errored.