### PR TITLE
fix https://github.com/mt-historical/i3/issues/7

### DIFF
--- a/src/gui.lua
+++ b/src/gui.lua
@@ -1576,7 +1576,7 @@ local function get_items_fs(fs, data, player, full_height)
 			local item_btn = fmt("item_image_button", X, Y, size, size, name, item, "")
 
 			if recipe_filter_set() and data.itab == 1 then
-				if data.items_progress[item] then
+				if data.items_progress and data.items_progress[item] then
 					insert(fs, item_btn)
 				else
 					local col = "^\\[colorize:#232428^\\[opacity:245"


### PR DESCRIPTION
see https://github.com/mt-historical/i3/issues/7 for context, while this ultimately does not solve the issue of the shield not being in `data.items_progress` (as the item i think should be added if the player has it in there inventory), ultimately it is probably best to have some safety here