### PR TITLE
prevent mod from crashing when privs are granted to players

### DIFF
--- a/src/common.lua
+++ b/src/common.lua
@@ -614,7 +614,7 @@ local function reset_data(data)
 	data.show_setting  = "home"
 	data.items         = data.items_raw
 
-	if data.itab > 1 then
+	if data.itab and data.itab > 1 then
 		sort_by_category(data)
 	end
 end


### PR DESCRIPTION
fixes the following bug

```
2024-08-30 19:27:25: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '' in callback on_chat_message(): ...games/farlands_reloaded/mods/fl_others/i3/src/common.lua:617: attempt to compare number with nil
2024-08-30 19:27:25: ERROR[Main]: stack traceback:
2024-08-30 19:27:25: ERROR[Main]:       ...games/farlands_reloaded/mods/fl_others/i3/src/common.lua:617: in function 'reset_data'
2024-08-30 19:27:25: ERROR[Main]:       ...es/farlands_reloaded/mods/fl_others/i3/src/callbacks.lua:49: in function 'func'
2024-08-30 19:27:25: ERROR[Main]:       /home/creativeworks/mt59/bin/../builtin/game/register.lua:432: in function 'run_priv_callbacks'
2024-08-30 19:27:25: ERROR[Main]:       /home/creativeworks/mt59/bin/../builtin/game/auth.lua:106: in function 'set_player_privs'
2024-08-30 19:27:25: ERROR[Main]:       /home/creativeworks/mt59/bin/../builtin/game/chat.lua:263: in function 'func'
2024-08-30 19:27:25: ERROR[Main]:       /home/creativeworks/mt59/bin/../builtin/game/chat.lua:79: in function </home/creativeworks/mt59/bin/../builtin/game/chat.lua:52>
2024-08-30 19:27:25: ERROR[Main]:       /home/creativeworks/mt59/bin/../builtin/common/register.lua:26: in function </home/creativeworks/mt59/bin/../builtin/common/register.lua:12>
```

taken from [farlands reloaded](https://github.com/terraquest-studios/farlands_reloaded) test server logs